### PR TITLE
Fix a bug when calculating the length of string containing non-ASCII characters

### DIFF
--- a/lib/binarypack.js
+++ b/lib/binarypack.js
@@ -326,7 +326,8 @@ Packer.prototype.pack_bin = function(blob){
 }
 
 Packer.prototype.pack_string = function(str){
-  var length = str.length;
+  var blob = new Blob(str);
+  var length = blob.size;
   if (length <= 0x0f){
     this.pack_uint8(0xb0 + length);
   } else if (length <= 0xffff){


### PR DESCRIPTION
According to [MDN:String/length](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String/length), the `length` property may not match the actual number of characters in the string, which is true for non-ASCII characters.

This bug can be verified by packing and unpacking the Chinese character 汉.

This push request fixed the bug by replacing `var length = str.length` with `var length = new Blob([str]).size` to get the real length in bytes in `Packer.prototype.pack_string`.
