### PR TITLE
Fix offset ignored in typed array

### DIFF
--- a/lib/binarypack.js
+++ b/lib/binarypack.js
@@ -300,9 +300,16 @@ Packer.prototype.pack = function (value) {
         }
       } else if ('BYTES_PER_ELEMENT' in value) {
         if (binaryFeatures.useArrayBufferView) {
-          this.pack_bin(new Uint8Array(value.buffer));
+          this.pack_bin(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
         } else {
-          this.pack_bin(value.buffer);
+          // Check if the typed array is a view over a larger ArrayBuffer
+          if (value.byteOffset !== 0 || value.byteLength !== value.buffer.byteLength) {
+            // If it is, copy it and use the new buffer
+            this.pack_bin(new Uint8Array(value).buffer);
+          } else {
+            // Otherwise use the buffer directly
+            this.pack_bin(value.buffer);
+          }
         }
       } else if ((constructor == Object) || (constructor.toString().startsWith('class'))) {
         this.pack_object(value);


### PR DESCRIPTION
Fixes https://github.com/peers/peerjs/issues/715, the only thing that worries me is that this results in an additional copy of the whole view (if 'useBufferView' is disabled).
But since it would only be performed when the typed array is a limited view over the underlying ArrayBuffer i think that it's acceptable.